### PR TITLE
Making it so all servers are torn down correctly

### DIFF
--- a/src/valkey_test_case.py
+++ b/src/valkey_test_case.py
@@ -509,9 +509,10 @@ class ValkeyTestCase(ValkeyTestCaseBase):
         self.server.wait_for_replicas(n)
 
     def teardown(self):
-        if self.server:
-            self.server.exit()
-            self.server = None
+        for server in self.server_list:
+            if server:
+                server.exit()
+                server = None
 
 
 class ValkeyReplica(ValkeyServerHandle):

--- a/tests/test_example_setup_per_test.py
+++ b/tests/test_example_setup_per_test.py
@@ -38,4 +38,3 @@ class TestExamplePerTestSetup(ValkeyTestCase):
             server_path=server_path,
         )
         self.new_client.execute_command("SET KEY VAL")
-        self.new_server.exit()


### PR DESCRIPTION
Now we work on the serverlist for teardown, which means any server created by create_server will be torn down without explicitly needing to be by the users 